### PR TITLE
lesson idea: use DatabaseSeeder.php to seed the database with 50 threads

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -1,6 +1,9 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use App\Channel;
+use App\Thread;
+use App\Reply;
 
 class DatabaseSeeder extends Seeder
 {
@@ -11,6 +14,16 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $channel = factory(Channel::class, 5)->create();
+        $channel->each(function (Channel $channel) {
+            $threads = factory(Thread::class, 10)->create([
+                'channel_id' => $channel->id
+            ]);
+            $threads->each(function (Thread $thread) {
+                factory(Reply::class, 10)->create([
+                    'thread_id' => $thread->id
+                ]);
+            });
+        });
     }
 }


### PR DESCRIPTION
use DatabaseSeeder.php to seed the database with 50 threads

Useful when you do artisan migrate:refresh --seed, you immediately have some content, and don't have to manually seed something in tinker.