### PR TITLE
Update User.php

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -87,6 +87,7 @@ class User extends Authenticatable
      */
     public function confirm()
     {
+        $this->confirmation_token = null;
         $this->confirmed = true;
 
         $this->save();


### PR DESCRIPTION
It is necessary to delete the old token, otherwise the confirmation link will still be valid even if the user is already confirmed.