### PR TITLE
Stop page reload after editing a reply

### DIFF
--- a/resources/assets/js/components/Reply.vue
+++ b/resources/assets/js/components/Reply.vue
@@ -16,7 +16,7 @@
 
         <div class="panel-body">
             <div v-if="editing">
-                <form @submit="update">
+                <form @submit.prevent="update">
                     <div class="form-group">
                         <textarea class="form-control" v-model="body" required></textarea>
                     </div>


### PR DESCRIPTION
 This PR adds the `.prevent` modifier on the @submit event in the form to edit a reply. Without this, the form submits and a full page reload happens. 

4th PR for Hacktoberfest 🤠